### PR TITLE
support exceptions better in `logfmt`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LoggingFormats"
 uuid = "98105f81-4425-4516-93fd-1664fb551ab6"
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/README.md
+++ b/README.md
@@ -66,11 +66,13 @@ level=info msg="hello, world" module=Main file="REPL[2]" line=2 group="REPL[2]" 
 level=error msg="something is wrong" module=Main file="REPL[2]" line=3 group="REPL[2]" id=Main_2289c7f8
 ```
 
+Similarly to the JSON logger, `LogFmt` handles the key `exception` specially, by printing errors and stacktraces using `Base.showerror`.
+
 ## `Truncated`: Truncate long variables and messages
 
 `LoggingFormats.Truncated(max_var_len=5_000)` is a function which formats data in similar manner as `ConsoleLogger`,
 but with truncation of string representation when it exceeds `max_var_len`.
-This format truncates the length of message itself, and truncates string representation of 
+This format truncates the length of message itself, and truncates string representation of
 individual variables, but does not truncate the size of whole printed text.
 
 See the examples:

--- a/src/LoggingFormats.jl
+++ b/src/LoggingFormats.jl
@@ -70,7 +70,6 @@ end
 transform(::Type{String}, v) = string(v)
 transform(::Type{Any}, v) = v
 
-# applies `f` to the message if it's an error
 function maybe_stringify_exceptions(key, v)
     key == :exception || return v
     if v isa Tuple && length(v) == 2 && v[1] isa Exception

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -203,7 +203,7 @@ end
     @test occursin("level=error msg=\"Oh no\" module=Main", str)
     @test occursin("file=\"", str)
     @test occursin("group=\"", str)
-    @test occursin("exception=\"ERROR: ArgumentError: no Stacktrace:", str)
+    @test occursin("exception=\"ERROR: ArgumentError: no\\nStacktrace:", str)
     # no new lines (except at the end of the line)
     @test !occursin('\n', chomp(str))
     # no Ptr's showing up in the backtrace


### PR DESCRIPTION
closes https://github.com/JuliaLogging/LoggingFormats.jl/issues/13

Before you would get stuff full of `Ptr{Nothing}` like 
```logfmt
level=error msg="Oh no" module=Main file="REPL[10]" line=5 group="REPL[10]" id=Main_5aa3f312 exception="(ArgumentError(\"no\"), Union{Ptr{Nothing}, Base.InterpreterIP}[Ptr{Nothing} @0x0000000167a9c08b, Ptr{Nothing} @0x000000016df44637, Ptr{Nothing} @0x000000016df44687, Ptr{Nothing} @0x0000000104d1dafb, Ptr{Nothing} @0x000000011c3aea8b, Ptr{Nothing} @0x00000001265a40cf, Ptr{Nothing} @0x00000001265a412b, Ptr{Nothing} @0x0000000104d1dafb, Ptr{Nothing} @0x0000000104d3823f, Ptr{Nothing} @0x0000000104d36a3b, Ptr{Nothing} @0x0000000104d3705b, Base.InterpreterIP in top-level CodeInfo for Main at statement 9, Ptr{Nothing} @0x0000000104d4f2b3, Ptr{Nothing} @0x0000000104d4f07b, Ptr{Nothing} @0x0000000104d4f07b, Ptr{Nothing} @0x0000000104d4f07b, Ptr{Nothing} @0x0000000104d4ff63, Ptr{Nothing} @0x000000011af3e0af, Ptr{Nothing} @0x000000011acc1873, Ptr{Nothing} @0x000000011bbf372f, Ptr{Nothing} @0x000000011c3536ab, Ptr{Nothing} @0x0000000104d1dafb, Ptr{Nothing} @0x000000011c351d0f, Ptr{Nothing} @0x000000011c35253f, Ptr{Nothing} @0x000000011acc264f, Ptr{Nothing} @0x0000000104d1dafb, Ptr{Nothing} @0x000000011b4697ef, Ptr{Nothing} @0x000000011b4698f7, Ptr{Nothing} @0x0000000104d1dafb, Ptr{Nothing} @0x0000000104d2bf57, Ptr{Nothing} @0x000000011beb9a13, Ptr{Nothing} @0x000000011b47da0b, Ptr{Nothing} @0x000000011bc1d58b, Ptr{Nothing} @0x000000011aceddab, Ptr{Nothing} @0x0000000104d1dafb, Ptr{Nothing} @0x0000000104d7b27f, Ptr{Nothing} @0x0000000104d7b173])"
```

Now you get
```logfmt
level=error msg="Oh no" module=Main file="REPL[156]" line=5 group="REPL[156]" id=Main_5aa3f327 exception="ERROR: ArgumentError: no Stacktrace:   [1] my_throwing_function()     @ Main ./REPL[154]:2   [2] (::var\"#162#163\")()     @ Main ./REPL[156]:3   [3] with_logstate(f::Function, logstate::Any)     @ Base.CoreLogging ./logging.jl:515   [4] with_logger(f::Function, logger::FormatLogger)     @ Base.CoreLogging ./logging.jl:627   [5] top-level scope     @ REPL[156]:1   [6] eval     @ Core ./boot.jl:385 [inlined]   [7] eval_user_input(ast::Any, backend::REPL.REPLBackend, mod::Module)     @ REPL ~/.julia/juliaup/julia-1.10.0+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:150   [8] repl_backend_loop(backend::REPL.REPLBackend, get_module::Function)     @ REPL ~/.julia/juliaup/julia-1.10.0+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:246   [9] start_repl_backend(backend::REPL.REPLBackend, consumer::Any; get_module::Function)     @ REPL ~/.julia/juliaup/julia-1.10.0+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:231  [10] run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_on_current_task::Bool, backend::Any)     @ REPL ~/.julia/juliaup/julia-1.10.0+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:389  [11] run_repl(repl::REPL.AbstractREPL, consumer::Any)     @ REPL ~/.julia/juliaup/julia-1.10.0+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:375  [12] (::Base.var\"#1013#1015\"{Bool, Bool, Bool})(REPL::Module)     @ Base ./client.jl:432  [13] #invokelatest#2     @ Base ./essentials.jl:887 [inlined]  [14] invokelatest     @ Base ./essentials.jl:884 [inlined]  [15] run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_file::Bool, color_set::Bool)     @ Base ./client.jl:416  [16] exec_options(opts::Base.JLOptions)     @ Base ./client.jl:333  [17] _start()     @ Base ./client.jl:552 "
```

Not beautiful, but at least it's not garbage, and still on one line, so your log aggregator shouldn't dump it into a million different messages.