### PR TITLE
handle exceptions in any key, as ConsoleLogger does

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ julia> with_logger(FormatLogger(LoggingFormats.JSON(; recursive=true), stderr)) 
 ```
 
 If it encounters something which does not have a defined `StructTypes.StructType` to use
-for serializing to JSON, it will fallback to converting the objects to strings, like the default `recursive=false` option does. Handles the key `exception` specially, by printing errors and stacktraces using `Base.showerror`.
+for serializing to JSON (or otherwise errors when serializing to JSON), it will fallback to converting the objects to strings, like the default `recursive=false` option does. Handles exceptions specially, by printing errors and stacktraces using `Base.showerror`.
 
 ```julia
 julia> f() = try
@@ -66,7 +66,7 @@ level=info msg="hello, world" module=Main file="REPL[2]" line=2 group="REPL[2]" 
 level=error msg="something is wrong" module=Main file="REPL[2]" line=3 group="REPL[2]" id=Main_2289c7f8
 ```
 
-Similarly to the JSON logger, `LogFmt` handles the key `exception` specially, by printing errors and stacktraces using `Base.showerror`.
+Similarly to the JSON logger, `LogFmt` handles exceptions specially, by printing errors and stacktraces using `Base.showerror`.
 
 ## `Truncated`: Truncate long variables and messages
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,15 +134,20 @@ end
         # no stacktrace
         io = IOBuffer()
         with_logger(FormatLogger(JSON(; recursive=recursive), io)) do
-            try
-                throw(ArgumentError("no"))
-            catch e
-                @error "Oh no" exception = e
-            end
+            @error "Oh no" exception = ArgumentError("no")
         end
         logs = JSON3.read(seekstart(io))
         @test logs["msg"] == "Oh no"
         @test logs["kwargs"]["exception"] == "ArgumentError: no"
+
+        # non-standard exception key
+        io = IOBuffer()
+        with_logger(FormatLogger(JSON(; recursive=recursive), io)) do
+            @error "Oh no" ex = ArgumentError("no")
+        end
+        logs = JSON3.read(seekstart(io))
+        @test logs["msg"] == "Oh no"
+        @test logs["kwargs"]["ex"] == "ArgumentError: no"
 
         # stacktrace
         io = IOBuffer()


### PR DESCRIPTION
I think it's technically possible this is less informative for the recursive JSON logger if one had very nice structured exceptions they were logging from a non-`exception` key and wanted to introspect from their log aggregator without parsing/regex. I think that is somewhat unlikely though, and that being consistent ConsoleLogger is probably more valuable.