### PR TITLE
allow customizing logfmt standard keys

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LoggingFormats"
 uuid = "98105f81-4425-4516-93fd-1664fb551ab6"
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ level=error msg="something is wrong" module=Main file="REPL[2]" line=3 group="RE
 
 Similarly to the JSON logger, `LogFmt` handles the key `exception` specially, by printing errors and stacktraces using `Base.showerror`.
 
+One can also restrict the "standard" keys used in the log message, for example:
+
+```julia
+julia> using LoggingFormats, LoggingExtras
+
+julia> with_logger(FormatLogger(LoggingFormats.LogFmt((:level, :message, :file)), stderr)) do
+           @info "hello, world" extra="bye"
+           @error "something is wrong"
+       end
+level=info msg="hello, world" file="REPL[5]" extra="bye"
+level=error msg="something is wrong" file="REPL[5]"
+```
+
+Note here that the `module`, `group`, `id` do not appear, since they weren't specified, but the "custom" key `extra` still appears. The full set of standard keys is `(:level, :msg, :module, :file, :line, :group, :id)`, which are all used by default, in that order.
+
 ## `Truncated`: Truncate long variables and messages
 
 `LoggingFormats.Truncated(max_var_len=5_000)` is a function which formats data in similar manner as `ConsoleLogger`,

--- a/src/LoggingFormats.jl
+++ b/src/LoggingFormats.jl
@@ -147,8 +147,6 @@ end
 ############
 # See  https://brandur.org/logfmt
 
-const STANDARD_KEYS = (:level, :msg, :module, :file, :line, :group, :id)
-
 """
     LogFmt(standard_keys=$STANDARD_KEYS)
     LogFmt(standard_keys...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,6 +164,22 @@ end
 end
 
 @testset "logfmt" begin
+    # Unsupported keys:
+    @test_throws ArgumentError("Unsupported standard logging key `:hi` found. The only supported keys are: `(:level, :msg, :module, :file, :line, :group, :id)`.") LogFmt((:hi,))
+    @test_throws ArgumentError("Unsupported standard logging keys `(:hi, :bye)` found. The only supported keys are: `(:level, :msg, :module, :file, :line, :group, :id)`.") LogFmt((:hi, :bye))
+    @test_throws MethodError LogFmt("no")
+
+    # Fewer keys, out of order
+    io = IOBuffer()
+    with_logger(FormatLogger(LogFmt(:msg, :level, :file), io)) do
+        @debug "debug msg" extra="hi"
+        @info "info msg" _file="file with space.jl"
+    end
+    strs = collect(eachline(seekstart(io)))
+    @test match(r"msg=\"debug msg\" level=debug file=\"(.*)\" extra=\"hi\"", strs[1]) !== nothing
+    @test strs[2] == "msg=\"info msg\" level=info file=\"file with space.jl\""
+
+    # Standard:
     io = IOBuffer()
     with_logger(FormatLogger(LogFmt(), io)) do
         @debug "debug msg"


### PR DESCRIPTION
as mentioned on Slack, this can be used to make simpler/cleaner logs in cases where you don't need `module`, `group`, `id`, etc, and are reading the logs directly rather than via an aggregator. I went for "fully customizable" (i.e. order + which keys) rather than special casing some (e.g. you probably always want `msg`, but might as well make it customizable).